### PR TITLE
Merge the branch to the default branch.

### DIFF
--- a/openj9_checkout_upstream_branch.sh
+++ b/openj9_checkout_upstream_branch.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+if [ "$#" -ne 1 ]
+then
+    echo "upstream branch absent"
+    exit
+fi
+
+BRANCH=$1
+DIRECTORY="openj9-openjdk-jdk8/openj9"
+cd $PWD/$DIRECTORY
+git remote add upstream git@github.com:eclipse-openj9/openj9.git
+git fetch --prune upstream
+git checkout -b $BRANCH upstream/$BRANCH
+git reset --hard upstream/$BRANCH
+
+git log
+
+cd -


### PR DESCRIPTION
I think openj9_checkout_upstream_branch.sh creates a
new remote branch from the upstream repository.

Closes: https://github.com/singh264/scripts/issues/17.
Signed-off-by: Amarpreet Singh amarpreet1997@gmail.com.